### PR TITLE
失格モードの切り替え機能の追加

### DIFF
--- a/lib/screens/score_screen.dart
+++ b/lib/screens/score_screen.dart
@@ -4,8 +4,8 @@ import 'team_selection_screen.dart';
 
 class ScoreScreen extends StatefulWidget {
   final List<String> teamNames;
-
-  ScoreScreen({required this.teamNames});
+  final bool enableDisqualification;  // 失格機能の状態を受け取る
+  ScoreScreen({required this.teamNames, required bool this.enableDisqualification});
 
   @override
   _ScoreScreenState createState() => _ScoreScreenState();
@@ -44,8 +44,10 @@ class _ScoreScreenState extends State<ScoreScreen> {
     // ダイアログを閉じる
     Navigator.of(context).pop();
 
-    // 失格の判定を得点の更新後に行う
-    _checkForDisqualification(index);
+    // 失格機能が有効な場合のみ失格の判定を行う
+    if (widget.enableDisqualification) {
+      _checkForDisqualification(index);
+    }
     
     // 勝利条件の確認
     _checkForWinner(players[index]);

--- a/lib/screens/team_name_screen.dart
+++ b/lib/screens/team_name_screen.dart
@@ -3,8 +3,10 @@ import 'score_screen.dart';
 
 class TeamNameScreen extends StatefulWidget {
   final int teamCount;
+  final bool enableDisqualification;
 
-  TeamNameScreen({required this.teamCount});
+  TeamNameScreen(
+      {required this.teamCount, required this.enableDisqualification});
 
   @override
   _TeamNameScreenState createState() => _TeamNameScreenState();
@@ -30,11 +32,15 @@ class _TeamNameScreenState extends State<TeamNameScreen> {
   }
 
   void _navigateToScoreScreen(BuildContext context) {
-    List<String> teamNames = _teamNameControllers.map((controller) => controller.text).toList();
+    List<String> teamNames =
+        _teamNameControllers.map((controller) => controller.text).toList();
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => ScoreScreen(teamNames: teamNames),
+        builder: (context) => ScoreScreen(
+          teamNames: teamNames,
+          enableDisqualification: widget.enableDisqualification,
+        ),
       ),
     );
   }

--- a/lib/screens/team_selection_screen.dart
+++ b/lib/screens/team_selection_screen.dart
@@ -9,6 +9,7 @@ class TeamSelectionScreen extends StatefulWidget {
 class _TeamSelectionScreenState extends State<TeamSelectionScreen> {
   final TextEditingController _teamCountController = TextEditingController();
   String _errorMessage = '';
+  bool _enableDisqualification = true;  // 失格機能のトグル状態
 
   @override
   void dispose() {
@@ -19,15 +20,16 @@ class _TeamSelectionScreenState extends State<TeamSelectionScreen> {
   void _navigateToTeamNameScreen(BuildContext context) {
     int? teamCount = int.tryParse(_teamCountController.text);
     if (teamCount != null && teamCount > 0) {
-      // チーム人数が入力されたら、チーム名入力画面に遷移
       Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (context) => TeamNameScreen(teamCount: teamCount),
+          builder: (context) => TeamNameScreen(
+            teamCount: teamCount,
+            enableDisqualification: _enableDisqualification,  // トグルボタンの状態を渡す
+          ),
         ),
       );
     } else {
-      // 入力が無効の場合、エラーメッセージを表示
       setState(() {
         _errorMessage = '有効なチーム数を入力してください (1以上の整数)';
       });
@@ -63,6 +65,24 @@ class _TeamSelectionScreenState extends State<TeamSelectionScreen> {
                   _errorMessage,
                   style: TextStyle(color: Colors.red, fontSize: 18),
                 ),
+              SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    _enableDisqualification ? '失格モード有効' : '失格モード無効',  // トグルに応じたテキスト
+                    style: TextStyle(fontSize: 20),
+                  ),
+                  Switch(
+                    value: _enableDisqualification,
+                    onChanged: (value) {
+                      setState(() {
+                        _enableDisqualification = value;
+                      });
+                    },
+                  ),
+                ],
+              ),
               SizedBox(height: 20),
               ElevatedButton(
                 onPressed: () => _navigateToTeamNameScreen(context),


### PR DESCRIPTION
モルックのルールであるチームで3回連続得点がゼロの場合はそのチームは失格となる失格のルールをトグルボタンで切り替えれるようにした


https://github.com/user-attachments/assets/6f839661-30ea-4d0f-adcb-f0720d0a585f



