### PR TITLE
Feature/add score sheet

### DIFF
--- a/lib/models/score_history.dart
+++ b/lib/models/score_history.dart
@@ -1,0 +1,6 @@
+class ScoreHistory {
+  final String playerName;
+  List<int> scores = [];
+
+  ScoreHistory({required this.playerName});
+}


### PR DESCRIPTION
・スコアシートの表示機能の追加：スコア履歴をテーブル形式で表示して，プレイヤーごとの得点過程を確認できるようにした

https://github.com/user-attachments/assets/b6699e65-1473-4714-bae5-2fe356feb2a0

・スコアの編集機能の追加：各スコアセルをタップできるようにして、タップされた場合は_editScore メソッドを呼び出してスコアの編集を行えるようにした

https://github.com/user-attachments/assets/96414b41-20a7-4bd3-88f8-66b764441985


